### PR TITLE
fix: check whether or not we created destination directory

### DIFF
--- a/src/main/java/com/google/cloud/DownloadComponentsMojo.java
+++ b/src/main/java/com/google/cloud/DownloadComponentsMojo.java
@@ -114,7 +114,8 @@ public class DownloadComponentsMojo extends AbstractMojo {
 
     // Ensure that the output directory exists
     if (!destinationDir.mkdirs()) {
-      getLog().info("Failed to create destination directory. Perhaps the directory already exists?");
+      getLog()
+          .info("Failed to create destination directory. Perhaps the directory already exists?");
     }
 
     // Update the cached manifest

--- a/src/main/java/com/google/cloud/DownloadComponentsMojo.java
+++ b/src/main/java/com/google/cloud/DownloadComponentsMojo.java
@@ -113,7 +113,9 @@ public class DownloadComponentsMojo extends AbstractMojo {
     }
 
     // Ensure that the output directory exists
-    destinationDir.mkdirs();
+    if (!destinationDir.mkdirs()) {
+      getLog().info("Failed to create destination directory. Perhaps the directory already exists?");
+    }
 
     // Update the cached manifest
     try {


### PR DESCRIPTION
`File#mkdirs()` will already throw security errors if it fails.  We don't want to fail here as `File.#mkdirs()` will return `false` if the directory already exists - thus we should only log this case if the later file write fails.

Fixes #47
