### PR TITLE
deps: latest shared config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.5.5</version>
+    <version>1.16.1</version>
   </parent>
 
   <scm>


### PR DESCRIPTION
The latest shared config enables the project to avoid using
nexus-staging-maven-plugin.
